### PR TITLE
Update PHP 8.3 version compatibility and dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
         "laminas/laminas-serializer": "^2.10",
         "phpbench/phpbench": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "laminas/laminas-serializer": "^2.10",
         "phpbench/phpbench": "^1.0"
     },
@@ -20,7 +20,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "7.4.99"
+            "php": "8.1.99"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c3f0194b722d214024441756f56851f",
+    "content-hash": "9ba87cbead08dca972a06482be383fe5",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -3939,7 +3939,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0"
+        "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ba87cbead08dca972a06482be383fe5",
+    "content-hash": "c978dc86156c75e742df7bd92497cd95",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -3939,11 +3939,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.4.99"
+        "php": "8.1.99"
     },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This commit updates the compatibility range to include PHP 8.3.0. It also includes updated versions of various dependencies in composer.lock, including "psr/container", "symfony/console", "symfony/service-contracts", among other packages. Additionally, this commit removes certain unnecessary extra fields and adapts the composer file to meet current package requirements.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | ye

### Description

* Add PHP 8.3 support
